### PR TITLE
Switch from gcc to cc for building libvorbis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ ogg-sys = "0.0.9"
 libc = "0.2.65"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 pkg-config = "0.3"

--- a/libvorbis/build.rs
+++ b/libvorbis/build.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+extern crate cc;
 extern crate pkg_config;
 
 use std::path::Path;
@@ -24,7 +24,7 @@ fn main() {
     let ogg_inc = std::env::var("DEP_OGG_INCLUDE").unwrap();
     let ogg_inc = Path::new(&ogg_inc);
 
-    gcc::Config::new()
+    cc::Build::new()
         .file("libvorbis/lib/analysis.c")
         .file("libvorbis/lib/bitrate.c")
         .file("libvorbis/lib/block.c")


### PR DESCRIPTION
Closes #4.